### PR TITLE
FEAT/HEAT-741 - daily build

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -4,6 +4,9 @@ description: Build, and optionally push, a Docker image
 inputs:
   project:
     description: Project name
+  dockerfile:
+    description: Dockerfile path
+    default: Dockerfile
   push:
     description: Whether to push images to the registry
     default: 'false'
@@ -29,6 +32,7 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         context: .
+        file: ${{ inputs.dockerfile}}
         push: ${{ inputs.push }}
         provenance: false
         tags: |

--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -1,0 +1,42 @@
+name: GitHub Actions Runner in Docker - Base
+on:
+  push:
+    paths:
+      - Dockerfile.base
+      - .github/workflows/build-base.yml
+    branches:
+      - main
+      - develop
+
+  schedule:
+    - cron:  '0 22 * * *'
+
+jobs:
+  ubuntu_base_latest_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Copy Repo Files
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Get GitHub organization or user
+        run: echo 'ORG='$(echo $(dirname ${GITHUB_REPOSITORY}) | awk '{print tolower($0)}') >> $GITHUB_ENV
+      - name: Set version
+        id: version
+        run: |
+          version=$(date '+%Y-%m-%d').${{ github.run_number }}.$(echo ${{ github.sha }} | cut -c1-7)
+          echo "version=$version" | tee -a "$GITHUB_OUTPUT"
+      - name: GitHub app JWT and installation access token generation
+        uses: jamestrousdale/github-app-jwt-token@0.1.4
+        id: generate-github-app-tokens
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+        
+      - name: Build Docker images
+        uses: ./.github/actions/docker-build
+        id: build
+        with:
+          project: hmpps-github-actions-runner-base
+          push: True
+          dockerfile: Dockerfile.base
+          version: ${{ steps.version.outputs.version }}
+          gh_auth_token: ${{ steps.generate-github-app-tokens.outputs.access-token }}

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -48,7 +48,7 @@ jobs:
           echo "version=$version" | tee -a "$GITHUB_OUTPUT"
 
       - name: Update Dockerfile FROM org
-        run: sed -i.bak "s/FROM.*/FROM ghcr.io/ministryofjustice/hmpps-actions-runner-base:latest/" Dockerfile
+        run: sed -i.bak "s/FROM.*/FROM ghcr.io\/ministryofjustice\/hmpps-actions-runner-base:latest/" Dockerfile
 
       - name: GitHub app JWT and installation access token generation
         uses: jamestrousdale/github-app-jwt-token@0.1.4

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -47,6 +47,9 @@ jobs:
           version=$(date '+%Y-%m-%d').${{ github.run_number }}.$(echo ${{ github.sha }} | cut -c1-7)
           echo "version=$version" | tee -a "$GITHUB_OUTPUT"
 
+      - name: Update Dockerfile FROM org
+        run: sed -i.bak "s/FROM.*/FROM ghcr.io/ministryofjustice/hmpps-actions-runner-base:latest/" Dockerfile
+
       - name: GitHub app JWT and installation access token generation
         uses: jamestrousdale/github-app-jwt-token@0.1.4
         id: generate-github-app-tokens

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,64 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        type: boolean
+        default: false
+      force-deploy:
+        type: boolean
+        default: false
+    outputs:
+      version:
+        value: ${{ jobs.build-docker.outputs.version }}
+  workflow_dispatch:
+    inputs:
+      push:
+        description: Push images
+        type: boolean
+        default: false
+
+env:
+  push: ${{ inputs.push }}
+  ghcr_token: ${{ secrets.GHCR_TOKEN}}
+
+jobs:
+  build-docker:
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+      packages: write
+    name: Docker build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project:
+          - hmpps-github-actions-runner
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set version
+        id: version
+        run: |
+          version=$(date '+%Y-%m-%d').${{ github.run_number }}.$(echo ${{ github.sha }} | cut -c1-7)
+          echo "version=$version" | tee -a "$GITHUB_OUTPUT"
+
+      - name: GitHub app JWT and installation access token generation
+        uses: jamestrousdale/github-app-jwt-token@0.1.4
+        id: generate-github-app-tokens
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+        
+      - name: Build Docker images
+        uses: ./.github/actions/docker-build
+        id: build
+        with:
+          project: ${{ matrix.project }}
+          push: ${{ env.push }}
+          version: ${{ steps.version.outputs.version }}
+          gh_auth_token: ${{ steps.generate-github-app-tokens.outputs.access-token }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,17 +20,6 @@ on:
         required: true      
 
 jobs:
-  build-base:
-    permissions:
-      contents: read
-      pull-requests: write
-      deployments: write
-      packages: write
-    name: Build
-    uses: ./.github/workflows/build-base.yml
-    with:
-      push: true
-    secrets: inherit
   build-runner:
     permissions:
       contents: read

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -52,7 +52,6 @@ jobs:
     name: Deploy to prod
     uses: ./.github/workflows/deploy.yml
     needs:
-      - build-base
       - build-runner
     with:
       environment: production

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -3,7 +3,7 @@ name: Build -> Deploy pipeline
 on:
   push:
     branches:
-      - '**'
+      - 'main'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,17 +20,29 @@ on:
         required: true      
 
 jobs:
-  build:
+  build-base:
     permissions:
       contents: read
       pull-requests: write
       deployments: write
       packages: write
     name: Build
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/build-base.yml
     with:
       push: true
     secrets: inherit
+  build-runner:
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+      packages: write
+    name: Build
+    uses: ./.github/workflows/build-runner.yml
+    with:
+      push: true
+    secrets: inherit 
+    
   
   # deploy_to_dev:
   #   name: Deploy to dev
@@ -51,8 +63,9 @@ jobs:
     name: Deploy to prod
     uses: ./.github/workflows/deploy.yml
     needs:
-      - build
+      - build-base
+      - build-runner
     with:
       environment: production
-      version: ${{ needs.build.outputs.version }}
+      version: ${{ needs.build-runner.outputs.version }}
     secrets: inherit

--- a/.github/workflows/scheduled_deployment.yml
+++ b/.github/workflows/scheduled_deployment.yml
@@ -14,7 +14,7 @@ jobs:
       deployments: write
       packages: write
     name: Build
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/build-runner.yml
     with:
       push: true
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,8 @@ ENV CONTAINER_USER="runner" \
 
 # Checked by renovate
 ENV ACTIONS_RUNNER_VERSION="2.327.1"
-ENV GIT_LFS_VERSION="3.7.0"
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
-
-# Copy the build scripts and install playwright
-COPY --chmod=700 build/ /tmp/build/
-RUN /tmp/build/install_base.sh
 
 RUN <<EOF
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,20 @@
+FROM ubuntu:noble
+LABEL org.opencontainers.image.vendor="Ministry of Justice" \
+      org.opencontainers.image.authors="HMPPS DPS" \
+      org.opencontainers.image.title="Actions Runner - Base Image" \
+      org.opencontainers.image.description="Actions Runner base image for HMPPS DPS" \
+      org.opencontainers.image.url="https://github.com/ministryofjustice/hmpps-github-actions-runner"
+
+ARG DUMB_INIT_VERSION="1.2.2"
+# TODO: remove git PPA and skopeo customizations for focal when focal hits EOL
+ENV GIT_LFS_VERSION="3.2.0"
+ENV VULNZ_VERSION="9.0.0"
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY --chmod=700 build/ /tmp/build/
+RUN /tmp/build/install_base.sh

--- a/build/config.json
+++ b/build/config.json
@@ -22,7 +22,8 @@
         "libcurl4-openssl-dev",
         "libpq-dev",
         "pkg-config",
-        "software-properties-common"
+        "software-properties-common",
+        "openjdk-17-jre-headless"
       ]
     },
     {

--- a/build/tools.sh
+++ b/build/tools.sh
@@ -116,6 +116,14 @@ function install_powershell() {
   ln -s /opt/powershell/pwsh /usr/bin/pwsh
 }
 
+function install_vulnz() {
+# install the latest version of the vulnz tool
+  mkdir -p /opt/vulnz/cache
+  curl -L -o /opt/vulnz/vulnz.jar https://github.com/jeremylong/open-vulnerability-cli/releases/download/v${VULNZ_VERSION}/vulnz-${VULNZ_VERSION}.jar
+  chmod -R a+xr /opt/vulnz
+  chmod -R a+w /opt/vulnz/cache
+}
+
 function install_tools() {
   local function_name
   # shellcheck source=/dev/null

--- a/helm_deploy/hmpps-github-actions-runner/values.yaml
+++ b/helm_deploy/hmpps-github-actions-runner/values.yaml
@@ -2,7 +2,7 @@
 generic-service:
   nameOverride: hmpps-github-actions-runner
 
-  replicaCount: 2 # we can start with one and do more
+  replicaCount: 4 # enough to run OWASP scans (hopefully)
 
   image:
     repository: ghcr.io/ministryofjustice/hmpps-github-actions-runner
@@ -33,6 +33,23 @@ generic-service:
   # namespace_secrets:
   #   [name of kubernetes secret]:
   #     [name of environment variable as seen by app]: [key of kubernetes secret to load]
+
+  env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+
+  envFrom:
+    - secretRef:
+        name: hmpps-github-actions-runner
+
+  args:
+    - |
+      ORDINAL=$((0x$(echo $POD_NAME | sha1sum | head -c 2) % 4))
+      API_KEY_VAR="NVD_API_KEY_${ORDINAL}"
+      export NVD_API_KEY="${!API_KEY_VAR}"
+      exec /usr/local/bin/entrypoint.sh
 
 generic-prometheus-alerts:
   targetApplication: hmpps-github-actions-runner

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/Dockerfile/"
+        "/^Dockerfile.*/"
       ],
       "matchStrings": [       
         "ENV ACTIONS_RUNNER_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
@@ -23,7 +23,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/Dockerfile/"
+        "/^Dockerfile.*/"
       ],
       "matchStrings": [       
         "ENV GIT_LFS_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
@@ -32,6 +32,34 @@
       "packageNameTemplate": "git-lfs/git-lfs",
       "versioningTemplate": "semver",
       "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+\\.\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Dockerfile.*/"
+      ],
+      "matchStrings": [       
+        "ENV VULNZ_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "jeremylong/open-vulnerability-cli",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>\\d+\\.\\d+\\.\\d+)$"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": [".*"],
+      "versioning": "digest"
     }
   ]
 }

--- a/src/usr/local/bin/entrypoint.sh
+++ b/src/usr/local/bin/entrypoint.sh
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+echo "Setting up NVD vulnerability database mirror"
+echo "File location: /opt/vulnz/vulnz.jar"
+echo "NVD API KEY: "${NVD_API_KEY:0:3}...${NVD_API_KEY: -3}"
+cd /opt/vulnz
+./vulnz.jar cve --cache --directory ./cache
+
+echo "Database mirror setup complete - now starting the runner"
+
 ACTIONS_RUNNER_DIRECTORY="/actions-runner"
 EPHEMERAL="${EPHEMERAL:-"false"}"
 


### PR DESCRIPTION
This is the first step in enabling a daily build.

It adds the functionality of a develop build to build the base on push, and restricts the main runner from being deployed only as part of a `main` push. 

This will enable base builds to be built so they can be evaluated and then we can move over to using it to build the main runner.