### PR TITLE
Optimize Dockerfile layer caching and suppress low-risk vulnerabilities

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,19 @@
+# Trivy vuln DB is incorrectly reporting CVE-2024-52308 as affecting gh version 2.83.1
+CVE-2024-52308
+
+# Vulnerabilities in bundled Node.js npm packages within GitHub Actions Runner
+# These are transitive dependencies of the runner binary itself, not code we control
+# The runner is distributed as a pre-compiled tarball from https://github.com/actions/runner
+# Monitor: https://github.com/actions/runner/security/advisories for upstream fixes
+
+# CVE-2024-21538: ReDoS vulnerability in cross-spawn <7.0.5
+# Affects: cross-spawn when processing maliciously crafted command strings
+# Risk assessment: Low - runner doesn't expose cross-spawn to external/untrusted input
+# Reference: https://github.com/advisories/GHSA-3xgq-45jj-v275
+CVE-2024-21538
+
+# CVE-2025-64756: Command injection in glob CLI tool via -c/--cmd flag with shell:true
+# Affects: glob <10.5.0 / <11.1.0 when used as CLI with specific flags
+# Risk assessment: Low - runner uses glob as a library dependency, not as a CLI tool
+# Reference: https://www.cve.org/CVERecord?id=CVE-2025-64756
+CVE-2025-64756

--- a/build/config.json
+++ b/build/config.json
@@ -30,7 +30,7 @@
         "libpq-dev",
         "pkg-config",
         "software-properties-common",
-        "openjdk-17-jre-headless"
+        "openjdk-21-jre-headless"
       ]
     },
     {

--- a/build/install_base.sh
+++ b/build/install_base.sh
@@ -33,8 +33,10 @@ function install_tools_apt() {
 }
 
 function remove_caches() {
+  apt-get clean
   rm -rf /var/lib/apt/lists/*
   rm -rf /tmp/*
+  rm -rf /var/tmp/*
 }
 
 function setup_sudoers() {


### PR DESCRIPTION
- Split Dockerfile into separate RUN layers for better caching
- Add BuildKit cache mounts for apt to speed up rebuilds
- Upgrade OpenJDK from 17 to 21
- Add .trivyignore for bundled Node.js CVEs in actions runner
- Improve cache cleanup in install_base.sh
