### PR TITLE
Preinstall Playwright browsers in runner image to remove workflow ins…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV CONTAINER_USER="runner" \
     CONTAINER_GROUP="runner" \
     CONTAINER_GID="10000" \
     CONTAINER_HOME="/actions-runner" \
+    PLAYWRIGHT_BROWSERS_PATH="/opt/playwright" \
     DEBIAN_FRONTEND="noninteractive" \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
@@ -44,6 +45,8 @@ RUN groupadd \
       --create-home \
       ${CONTAINER_USER} && \
     mkdir --parents ${CONTAINER_HOME} && \
+    mkdir --parents ${PLAYWRIGHT_BROWSERS_PATH} && \
+    chown --recursive ${CONTAINER_USER}:${CONTAINER_GROUP} ${PLAYWRIGHT_BROWSERS_PATH} && \
     chown --recursive ${CONTAINER_USER}:${CONTAINER_GROUP} ${CONTAINER_HOME}
 
 # Download and install GitHub Actions runner (changes frequently with ACTIONS_RUNNER_VERSION)

--- a/build/tools.sh
+++ b/build/tools.sh
@@ -95,8 +95,8 @@ function install_playwright() {
   mkdir -p /opt/playwright
   export PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
   npm install -g playwright
-  # Install OS dependencies in the image; workflows can install browser binaries as non-root.
-  npx playwright install-deps chrome-for-testing chromium-headless-shell firefox webkit ffmpeg chrome msedge
+  # Pre-install browsers and OS dependencies so workflows do not need runtime install steps.
+  npx playwright install --with-deps chrome-for-testing chromium-headless-shell firefox webkit ffmpeg chrome msedge
   npm uninstall -g playwright
   npm cache clean --force
   # Remove Node.js after Playwright deps installed - workflows use actions/setup-node


### PR DESCRIPTION
…tall step

1. set PLAYWRIGHT_BROWSERS_PATH to /opt/playwright
2. create and chown browser cache path for the runner user
3. update install_playwright to run playwright install --with-deps for required browsers
4. avoid workflow-time msedge install and failures caused by no_new_privileges/sudo restrictions